### PR TITLE
Fixed bash scripts for more compatibility

### DIFF
--- a/run_mitm.sh
+++ b/run_mitm.sh
@@ -1,1 +1,2 @@
-python -m cuwo.mitm
+#!/bin/sh
+/usr/bin/env python2 -m cuwo.mitm

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,1 +1,2 @@
-python -m cuwo.server
+#!/bin/sh
+/usr/bin/env python2 -m cuwo.server


### PR DESCRIPTION
/usr/bin/env should be available on all distro's (It's a standard). It automatically choses the right python2 installation to run the script.
Also added a hashbang (#!) to be able to run the script with "./script.sh" after adding the executable bit.
