### PR TITLE
fix for rare bug in chat display

### DIFF
--- a/scripts/irc.py
+++ b/scripts/irc.py
@@ -197,7 +197,7 @@ class IRCScriptConnection(ConnectionScript):
             self.connection.name))
 
     def on_chat(self, event):
-        message = encode_irc('<\x036%s\x0F> %s' % (
+        message = encode_irc('<\x0306%s\x0F> %s' % (
             self.connection.name, event.message))
         self.parent.send(message)
 


### PR DESCRIPTION
when a character's name begins with a number, for example with the name "1st", the 6 for colour will be parsed as a 61, eating the 1, leaving a colourless <st>
Changing to \x0306 will prevent the number in the name from being parsed.
