### PR TITLE
Give console an identity, catch name=None from console

### DIFF
--- a/cuwo/script.py
+++ b/cuwo/script.py
@@ -47,7 +47,7 @@ def get_player(server, value):
                 return player
             if name.count(value):
                 ret = player
-    except (KeyError, IndexError, ValueError):
+    except (KeyError, IndexError, ValueError, AttributeError):
         pass
     if ret is None:
         raise InvalidPlayer()

--- a/scripts/console.py
+++ b/scripts/console.py
@@ -79,6 +79,7 @@ class ConsoleInput(LineReceiver):
     def __init__(self, server):
         self.server = server
         self.interface = ScriptInterface(server, 'admin', 'console')
+        self.interface.connection.name = 'Console'
 
     def lineReceived(self, line):
         if line.startswith('/'):


### PR DESCRIPTION
- Name the console so `script.connection.name` in commands such as `/pm` will return 'Console' if ran from the console (e.g. "Console (PM): private message from the console")
- Catch `AttributeError: 'NoneType' object has no attribute 'startswith'` when running a command like `/whereis` from the console without a name argument
