### PR TITLE
Make size parameter of ByteReader.read optional.

### DIFF
--- a/cuwo/bytes.pxd
+++ b/cuwo/bytes.pxd
@@ -33,7 +33,7 @@ cdef class ByteReader:
 
     cpdef inline unsigned int get_left(self)
     cdef inline char * check_available(self, unsigned int size) except NULL
-    cpdef inline bytes read(self, unsigned int size)
+    cpdef inline bytes read(self, unsigned int size=*)
     cpdef inline bytes read_string(self, unsigned int size)
     cpdef inline unicode read_ascii(self, unsigned int size)
     cpdef inline skip(self, unsigned int size)

--- a/cuwo/bytes.pyx
+++ b/cuwo/bytes.pyx
@@ -89,7 +89,9 @@ cdef class ByteReader:
         self.pos += size
         return data
 
-    cpdef bytes read(self, unsigned int size):
+    cpdef bytes read(self, unsigned int size=-1):
+        if size == -1:
+            size = self.get_left()
         cdef char * pos = self.check_available(size)
         return pos[:size]
 


### PR DESCRIPTION
- Reads left data when no size parameter is supplied

(As it is expected in qmo.py)
